### PR TITLE
Replaces hardcoded 'admin' username with user from login command

### DIFF
--- a/lib/ops_manager/api/opsman.rb
+++ b/lib/ops_manager/api/opsman.rb
@@ -145,7 +145,7 @@ class OpsManager
       end
 
       def get_token
-        token_issuer.owner_password_grant('admin', password, 'opsman.admin').tap do |token|
+        token_issuer.owner_password_grant(username, password, 'opsman.admin').tap do |token|
           logger.info "UAA Token: #{token.inspect}"
         end
       rescue  CF::UAA::TargetError

--- a/spec/ops_manager/api/opsman_spec.rb
+++ b/spec/ops_manager/api/opsman_spec.rb
@@ -14,7 +14,7 @@ describe OpsManager::Api::Opsman do
 
   before do
     allow(token_issuer).to receive(:owner_password_grant)
-      .with('admin', password, 'opsman.admin')
+      .with(username, password, 'opsman.admin')
       .and_return(uaa_token)
     allow(CF::UAA::TokenIssuer).to receive(:new)
       .with("https://#{target}/uaa", 'opsman', nil, skip_ssl_validation: true)


### PR DESCRIPTION
This allows the username passed to the `ops_manager login` command to be used in lieu of the hardcoded `admin` user. Fixes #2.

@compozed/platform
