### PR TITLE
Fix issue when collecting errands for applying changes

### DIFF
--- a/lib/ops_manager/installation_runner.rb
+++ b/lib/ops_manager/installation_runner.rb
@@ -64,7 +64,7 @@ class OpsManager
     def errands_for(product_guid)
       res = get_staged_products_errands(product_guid)
 
-      if res.code == 200
+      if res.code == '200'
         JSON.parse(res.body)['errands']
       else
         []

--- a/spec/ops_manager/installation_runner_spec.rb
+++ b/spec/ops_manager/installation_runner_spec.rb
@@ -22,7 +22,7 @@ describe OpsManager::InstallationRunner do
     let(:get_staged_products_response){ double( body: [ { "guid" =>  product_guid }].to_json, code: 200) }
     let(:get_staged_products_errands_response) do
       double(
-        code: 200,
+        code: '200',
         body:
         { "errands" => [
           { "name" => "errand1",


### PR DESCRIPTION
This fixes an issue where errands would never be added to the `trigger_installation` body since `res.code` was being checked against an integer rather than a string.

The response code is a String per: https://ruby-doc.org/stdlib-2.2.0/libdoc/net/http/rdoc/Net/HTTPResponse.html

@bonzofenix 
