### PR TITLE
Ensures special shell characters are escaped in ovftool command

### DIFF
--- a/lib/ops_manager/deployments/vsphere.rb
+++ b/lib/ops_manager/deployments/vsphere.rb
@@ -1,5 +1,6 @@
 require 'rbvmomi'
 require "uri"
+require 'shellwords'
 require "ops_manager/logging"
 
 class OpsManager
@@ -30,11 +31,11 @@ class OpsManager
       end
 
       def vcenter_username
-        URI.encode(config.opts['vcenter']['username'])
+        Shellwords.escape(URI.encode(config.opts['vcenter']['username']))
       end
 
       def vcenter_password
-        URI.encode(config.opts['vcenter']['password'])
+        Shellwords.escape(URI.encode(config.opts['vcenter']['password']))
       end
     end
   end

--- a/ops_manager.gemspec
+++ b/ops_manager.gemspec
@@ -28,4 +28,5 @@ Gem::Specification.new do |spec|
   spec.add_dependency "net-ping"
   spec.add_dependency "cf-uaa-lib"
   spec.add_dependency "session_config"
+  spec.add_dependency "rubysl-shellwords"
 end

--- a/spec/ops_manager/deployments/vsphere_spec.rb
+++ b/spec/ops_manager/deployments/vsphere_spec.rb
@@ -43,16 +43,15 @@ describe OpsManager::Deployments::Vsphere do
 
     %w{username password}.each do |m|
       describe "when vcenter_#{m} has unescaped character" do
-        before { config.opts['vcenter'][m] = "domain\\vcenter_#{m}" }
+        before { config.opts['vcenter'][m] = "domain\\vcenter_+)#{m}" }
 
         it "should URL encode the #{m}" do
-          expect(vsphere).to receive(:`).with(/domain%5Cvcenter_#{m}/)
+          expect(vsphere).to receive(:`).with(/domain\\%5Cvcenter_\\\+\\\)#{m}/)
           deploy_vm
         end
       end
     end
   end
-
 
   describe 'stop_current_vm' do
     let(:vm_name){ 'ops-manager-1.4.2.0' }


### PR DESCRIPTION
This ensures that any special shell characters built into the `ovftool` command are escaped properly. This will allow for passwords with special characters such as `? @ + # < > (  )  { } [  ] ,` etc.
