### PR TITLE
Add pending-changes CLI command

### DIFF
--- a/lib/ops_manager/api/opsman.rb
+++ b/lib/ops_manager/api/opsman.rb
@@ -157,6 +157,23 @@ class OpsManager
         nil
       end
 
+      def pending_changes(opts = {})
+        print_green '====> Getting pending changes ...'
+        res = authenticated_get('/api/v0/staged/pending_changes')
+        pendingChanges = JSON.parse(res.body)
+
+        if pendingChanges['product_changes'].count == 0
+          puts "\nNo pending changes"
+        else
+          pendingChanges['product_changes'].each do |product|
+            puts "\n#{product['guid']}"
+          end
+        end
+
+        say_green 'done'
+        res
+      end
+
       def username
         @username ||= OpsManager.get_conf(:username)
       end

--- a/lib/ops_manager/cli.rb
+++ b/lib/ops_manager/cli.rb
@@ -72,6 +72,12 @@ class OpsManager
       end
     end
 
+    class PendingChanges < Clamp::Command
+      def execute
+        OpsManager::Api::Opsman.new.pending_changes
+      end
+    end
+
     class DeleteUnusedProducts < Clamp::Command
 
       def execute
@@ -158,6 +164,7 @@ class OpsManager
     subcommand "get-installation-settings", "Gets installation settings", GetInstallationSettings
     subcommand "get-installation-logs", "Gets installation logs", GetInstallationLogs
     subcommand "import-stemcell", "Uploads stemcell to OpsManager", ImportStemcell
+    subcommand "pending-changes", "View pending changes in OpsManager", PendingChanges
 
   end
 end

--- a/spec/ops_manager/api/opsman_spec.rb
+++ b/spec/ops_manager/api/opsman_spec.rb
@@ -519,4 +519,26 @@ describe OpsManager::Api::Opsman do
       expect(WebMock).to have_requested(:get, uri)
     end
   end
+
+  describe "#pending_changes" do
+    subject(:pending_changes){ opsman.pending_changes }
+
+    let(:response_body){ '{"product_changes":[{"guid":"product-1","action":"update","errands":[]}]}' }
+    let(:response){ pending_changes }
+    let(:status_code){ 200 }
+    let(:uri){ "#{base_uri}/api/v0/staged/pending_changes" }
+
+    before do
+      stub_request(:get, uri).to_return(status: status_code, body: response_body)
+    end
+
+    it "should run successfully" do
+      expect(response.code).to eq("200")
+    end
+
+    it "should include product changes in its body" do
+      expected_value = JSON.parse('{"product_changes":[{"guid":"product-1","action":"update","errands":[]}]}')
+      expect(parsed_response).to eq(expected_value)
+    end
+  end
 end

--- a/spec/ops_manager/cli_spec.rb
+++ b/spec/ops_manager/cli_spec.rb
@@ -88,6 +88,17 @@ describe OpsManager::Cli do
     end
   end
 
+  describe 'pending-changes' do
+    let(:args) { %w(pending-changes) }
+    let(:pending_changes_response) { 'No pending changes' }
+
+    it "should call ops_manager.pending_changes" do
+      allow(opsman_api).to receive(:pending_changes).and_return(pending_changes_response)
+      expect_any_instance_of(OpsManager::Cli::PendingChanges).to receive(:run)
+      cli.run(`pwd`, args)
+    end
+  end
+
   describe 'import-stemcell' do
     let(:args) { %w(import-stemcell /tmp/is.yml) }
 


### PR DESCRIPTION
Adding pending-changes to the CLI to make it easier to check for pending changes in Ops Manager and lists the GUIDs of products with pending changes.