### PR TITLE
Cannot create Ops Manager VM when it does not exist.

### DIFF
--- a/lib/ops_manager/api/opsman.rb
+++ b/lib/ops_manager/api/opsman.rb
@@ -121,7 +121,7 @@ class OpsManager
 
       def get_diagnostic_report
         authenticated_get("/api/v0/diagnostic_report")
-      rescue Errno::ETIMEDOUT , Errno::EHOSTUNREACH, Net::HTTPFatalError, Net::OpenTimeout
+      rescue Errno::ETIMEDOUT , Errno::EHOSTUNREACH, Net::HTTPFatalError, Net::OpenTimeout, HTTPClient::ConnectTimeoutError
         nil
       end
 

--- a/spec/ops_manager/api/opsman_spec.rb
+++ b/spec/ops_manager/api/opsman_spec.rb
@@ -318,8 +318,8 @@ describe OpsManager::Api::Opsman do
         with(:headers => {'Authorization'=>'Bearer UAA_ACCESS_TOKEN'})
     end
 
-    [ Net::OpenTimeout, Errno::ETIMEDOUT ,
-      Net::HTTPFatalError.new( '', '' ), Errno::EHOSTUNREACH ].each do |error|
+    [ Net::OpenTimeout, Errno::ETIMEDOUT , Net::HTTPFatalError.new( '', '' ),
+      Errno::EHOSTUNREACH, HTTPClient::ConnectTimeoutError ].each do |error|
       describe "when there is no ops manager and request errors: #{error}" do
 
         it "should be nil" do


### PR DESCRIPTION
When initially deploying the Ops Manager appliance the CLI attempts to get a diagnostic report through the Ops Manager API. When it calls to the API it uses a UAA token which cannot be retrieved due to a timeout as the VM does not exist. 

The UAA should return nil on timeout and continue to deploy a new VM. Added rescue on HTTP client timeout with the Ops Manager VM.

Stack trace:
```
/usr/local/bundle/gems/httpclient-2.8.3/lib/httpclient/session.rb:611:in `initialize': execution expired (HTTPClient::ConnectTimeoutError)
    from /usr/local/bundle/gems/httpclient-2.8.3/lib/httpclient/session.rb:611:in `new'
    from /usr/local/bundle/gems/httpclient-2.8.3/lib/httpclient/session.rb:611:in `create_socket'
    from /usr/local/bundle/gems/httpclient-2.8.3/lib/httpclient/ssl_socket.rb:21:in `create_socket'
    from /usr/local/bundle/gems/httpclient-2.8.3/lib/httpclient/session.rb:752:in `block in connect'
    from /usr/local/lib/ruby/2.3.0/timeout.rb:101:in `timeout'
    from /usr/local/bundle/gems/httpclient-2.8.3/lib/httpclient/session.rb:748:in `connect'
    from /usr/local/bundle/gems/httpclient-2.8.3/lib/httpclient/session.rb:511:in `query'
    from /usr/local/bundle/gems/httpclient-2.8.3/lib/httpclient/session.rb:177:in `query'
    from /usr/local/bundle/gems/httpclient-2.8.3/lib/httpclient.rb:1242:in `do_get_block'
    from /usr/local/bundle/gems/httpclient-2.8.3/lib/httpclient.rb:1019:in `block in do_request'
    from /usr/local/bundle/gems/httpclient-2.8.3/lib/httpclient.rb:1133:in `protect_keep_alive_disconnected'
    from /usr/local/bundle/gems/httpclient-2.8.3/lib/httpclient.rb:1014:in `do_request'
    from /usr/local/bundle/gems/httpclient-2.8.3/lib/httpclient.rb:856:in `request'
    from /usr/local/bundle/gems/httpclient-2.8.3/lib/httpclient.rb:765:in `post'
    from /usr/local/bundle/gems/cf-uaa-lib-3.10.0/lib/uaa/http.rb:164:in `net_http_request'
    from /usr/local/bundle/gems/cf-uaa-lib-3.10.0/lib/uaa/http.rb:145:in `request'
    from /usr/local/bundle/gems/cf-uaa-lib-3.10.0/lib/uaa/token_issuer.rb:77:in `request_token'
    from /usr/local/bundle/gems/cf-uaa-lib-3.10.0/lib/uaa/token_issuer.rb:242:in `owner_password_grant'
    from /usr/local/bundle/gems/ops_manager_cli-0.5.4/lib/ops_manager/api/opsman.rb:154:in `get_token'
    from /usr/local/bundle/gems/ops_manager_cli-0.5.4/lib/ops_manager/api/opsman.rb:180:in `access_token'
    from /usr/local/bundle/gems/ops_manager_cli-0.5.4/lib/ops_manager/api/opsman.rb:190:in `authorization_header'
    from /usr/local/bundle/gems/ops_manager_cli-0.5.4/lib/ops_manager/api/base.rb:162:in `add_authentication'
    from /usr/local/bundle/gems/ops_manager_cli-0.5.4/lib/ops_manager/api/base.rb:14:in `block (2 levels) in <class:Base>'
    from /usr/local/bundle/gems/ops_manager_cli-0.5.4/lib/ops_manager/api/opsman.rb:123:in `get_diagnostic_report'
    from /usr/local/bundle/gems/ops_manager_cli-0.5.4/lib/ops_manager/appliance_deployment.rb:159:in `diagnostic_report'
    from /usr/local/bundle/gems/ops_manager_cli-0.5.4/lib/ops_manager/appliance_deployment.rb:163:in `version_from_diagnostic_report'
    from /usr/local/bundle/gems/ops_manager_cli-0.5.4/lib/ops_manager/appliance_deployment.rb:131:in `current_version'
    from /usr/local/bundle/gems/ops_manager_cli-0.5.4/lib/ops_manager/appliance_deployment.rb:29:in `run'
    from /usr/local/bundle/gems/ops_manager_cli-0.5.4/lib/ops_manager/cli.rb:38:in `execute'
    from /usr/local/bundle/gems/clamp-1.1.2/lib/clamp/command.rb:63:in `run'
    from /usr/local/bundle/gems/clamp-1.1.2/lib/clamp/subcommand/execution.rb:11:in `execute'
    from /usr/local/bundle/gems/clamp-1.1.2/lib/clamp/command.rb:63:in `run'
    from /usr/local/bundle/gems/clamp-1.1.2/lib/clamp/command.rb:132:in `run'
    from /usr/local/bundle/gems/ops_manager_cli-0.5.4/exe/ops_manager:4:in `<top (required)>'
    from /usr/local/bundle/bin/ops_manager:22:in `load'
    from /usr/local/bundle/bin/ops_manager:22:in `<main>'
```