### PR TITLE
Make it work with ruby other than 2.4

### DIFF
--- a/lib/ops_manager/appliance/aws.rb
+++ b/lib/ops_manager/appliance/aws.rb
@@ -40,7 +40,7 @@ class OpsManager
         # Create ami of stopped server
         response = connection.create_image(server.id, "#{name}-backup", "Backup of #{name}")
         image = connection.images.get( response.data[:body]['imageId'])
-        image.wait_for 36000 { image.state == "available" }
+        image.wait_for(timeout=36000) { image.state == "available" }
         if image.state != "available"
           fail "Error creating backup AMI, bailing out before destroying the VM"
         end


### PR DESCRIPTION
Fixes an odd bug that makes this only work with ruby 2.4. This enables it to work with other 2.x rubies.

Signed-off-by: Geoff Franks <Geoff.Franks@allstate.com>